### PR TITLE
Release 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,10 @@ This module is aimed at anyone who manages many symlinks on their system, either
 <br>
 
 [![Build Status](https://dev.azure.com/KubaP999/Symlink/_apis/build/status/Development%20CI?branchName=development)](https://dev.azure.com/KubaP999/Symlink/_build/latest?definitionId=13&branchName=development)
-[![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/KubaP999/Symlink/13?logo=codecov&logoColor=white)](https://dev.azure.com/KubaP999/Symlink/_build?definitionId=13)
-[![PowerShell Gallery Version](https://img.shields.io/powershellgallery/v/ProgramManager?logo=powershell&logoColor=white)](https://www.powershellgallery.com/packages/Symlink)
-/\ Replace this one with a shields.io badge. Go to 'Version' -> 'Powershell Gallery (inc. pre-release)'
-    Fill out package name
-    logo = 'powershell'
-    logoColour = 'white'
-![PowerShell Gallery Platform](https://img.shields.io/powershellgallery/p/ProgramManager?logo=windows)
-/\ Replace this one with a shields.io badge. Go to 'Platform Support' -> 'Powershell Gallery'
-    Fill out package name
-    logo = 'windows'
-    logoColour = 'white'
+[![PowerShell Gallery Version](https://img.shields.io/powershellgallery/v/symlink?include_prereleases&logo=powershell&logoColor=white)](https://www.powershellgallery.com/packages/Symlink)
+![PowerShell Gallery Platform](https://img.shields.io/powershellgallery/p/symlink?logo=windows&logoColor=white)
 [![License](https://img.shields.io/badge/license-GPLv3-blue)](./LICENSE)
+<!-- [![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/KubaP999/Symlink/13?logo=codecov&logoColor=white)](https://dev.azure.com/KubaP999/Symlink/_build?definitionId=13) -->
 
 ### Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -89,11 +89,15 @@ When creating a new symlink, you can pass in a scriptblock which will evaluate w
 
 For details, see the `CREATION CONDITION SCRIPTBLOCK` section in `about_Symlink`.
 
-#### ~~-WhatIf and -Confirm support~~ [TODO]
-~~The following functions support `-WhatIf` and `-Confirm` parameters:~~
+#### -WhatIf and -Confirm support
+The following functions support `-WhatIf` and `-Confirm` parameters:
+- `New-Symlink`
+- `Remove-Symlink`
+- `Set-Symlink`
+- `Build-Symlink`
 
-~~Use `-WhatIf` to see and list what changes a command will do.~~
-~~Use `-Confirm` to ask for a prompt for every state-altering change.~~
+Use `-WhatIf` to see a list of what changes a command will do.
+Use `-Confirm` to ask for a prompt for every state-altering change.
 
 #### Formatting
 The `[Symlink]` object within this module has custom formatting rules for all views. Simply pipe the output of the `Get-Symlink` command to one of:

--- a/Symlink/Symlink.psd1
+++ b/Symlink/Symlink.psd1
@@ -72,7 +72,7 @@
 			# Tags applied to this module. These help with module discovery in online galleries.
 			# TODO: Add Mac/Linux tags once module confirmed working on those platforms.
 			# TODO: Add PS_Desktop tag once module confirmed working on powershell 5.1.
-			Tags = @("Windows","Symlink","Symbolic_Link","PSEdition_Core")
+			Tags = @("Windows","Symlink","Symbolic_Link","PSEdition_Core","Management","File","Folder")
 			
 			# A URL to the license for this module.
 			LicenseUri = 'https://www.gnu.org/licenses/gpl-3.0.en.html'

--- a/Symlink/changelog.md
+++ b/Symlink/changelog.md
@@ -1,4 +1,12 @@
 ﻿# Changelog
+## 0.1.1 (2020-10-17)
+ - Update: about_pages: Add information regarding common parameters.
+ - Update: help_descriptions: Extra examples for all commands.
+ - Update: output: Improve verbose logging to make it clearer and more succinct.
+ - Fix: Build-Symlink: Error when calling now-removed method on the \[Symlink\] object.
+ - Add: should_process: Support for most commands to use the -WhatIf and -Confirm switches.
+ - Update: New-Symlink: Outputs the newly-created \[Symlink\] object at the end.
+ - Fix: error_status: Only sets the $error variable if a true error has occured.
 ## 0.1.0 (2020-10-14)
  - Added: New-Symlink: Allows for defining a new symlink object, and creating it on the filesystem.
  - Added: Get-Symlink: Allows for retrieving an existing symlink object, and displaying it to the screen or piping it to other commands.
@@ -8,5 +16,5 @@
  - Added: about_pages: Includes all details regarding command invocations, general module information, and key data points.
  - Added: help_descriptions: Thorough descriptions of all commands along with multiple examples and important notes.
  - Added: tab_completion: Tab completion functionality for all commands for appropriate parameters.
- - Added: Symlink_object: Implementation of symlink logic as part of a custom class with appropriate public getters/setters for properties and methods.
+ - Added: \[Symlink\]: Implementation of symlink logic as part of a custom object with appropriate public getters/setters for properties and methods.
  - Added: Format.ps1xml: Custom formatting for the symlink object, supporting all 4 formatting views. Also included alternative formatting outputs if running in certain terminals, for enhanced readability.

--- a/Symlink/en-us/about_SYMLINK.help.txt
+++ b/Symlink/en-us/about_SYMLINK.help.txt
@@ -284,6 +284,8 @@ OTHER
     
 KEYWORDS
     Symlink
-    Symbolic Link
+    Symbolic_Link
     Management
+    File
+    Folder
     

--- a/Symlink/en-us/about_SYMLINK.help.txt
+++ b/Symlink/en-us/about_SYMLINK.help.txt
@@ -88,6 +88,18 @@ CREATING A SYMLINK
     -DontCreateItem
         Skips the creation of the symbolic-link item on the filesystem.
     
+    -WhatIf
+        Prints what actions would have been done in a proper run, but doesn't
+        perform any of them.
+    
+    -Confirm
+        Prompts for user input for every "altering"/changing action.
+    
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216).
     
     
 RETRIEVING A SYMLINK
@@ -147,6 +159,21 @@ CHANGING A SYMLINK
     -Value
         The new value for the property to take.
     
+    OPTIONAL PARAMETERS
+    
+    -WhatIf
+        Prints what actions would have been done in a proper run, but doesn't
+        perform any of them.
+    
+    -Confirm
+        Prompts for user input for every "altering"/changing action.
+    
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216).
+    
     
  2. To change any other properties of a symlink, run:
     
@@ -188,6 +215,19 @@ REMOVING A SYMLINK
         Skips the deletion of the symbolic-link item on the filesystem. The
         link will remain afterwads.
     
+    -WhatIf
+        Prints what actions would have been done in a proper run, but doesn't
+        perform any of them.
+    
+    -Confirm
+        Prompts for user input for every "altering"/changing action.
+    
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216).
+    
     
  2. To remove multiple symlinks, run:
     
@@ -212,6 +252,21 @@ BUILDING/UPDATING SYMLINKS
     
     -All
         Specifies to create all symlinks.
+    
+    OPTIONAL PARAMETERS
+    
+    -WhatIf
+        Prints what actions would have been done in a proper run, but doesn't
+        perform any of them.
+    
+    -Confirm
+        Prompts for user input for every "altering"/changing action.
+    
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216).
     
     
  2. To create only certain symbolic-links on the filesystem, run:

--- a/Symlink/functions/Build-Symlink.ps1
+++ b/Symlink/functions/Build-Symlink.ps1
@@ -67,15 +67,14 @@ function Build-Symlink {
 			# Read in all of the existing symlinks.
 			$linkList = Read-Symlinks
 			
-			Write-Verbose "Creating all symbolic-link items on the filesystem."
 			foreach ($link in $linkList) {
-				Write-Verbose "Creating the symlink: '$($link.Name)'."
+				Write-Verbose "Creating the symbolic-link item for: '$($link.Name)'."
 				
 				# Record the state for displaying at the end.
 				if ($link.Exists() -eq $false) {
 					$newList.Add($link)
 				}
-				elseif ($link.NeedsModification()) {
+				elseif ($link.State() -eq "NeedsDeletion" -or $link.State() -eq "NeedsCreation") {
 					$modifiedList.Add($link)
 				}
 				
@@ -87,15 +86,14 @@ function Build-Symlink {
 			# Read in the specified symlinks.
 			$linkList = Get-Symlink -Names $Names -Verbose:$false
 			
-			Write-Verbose "Creating specified symbolic-link items: '$Names' on the filesystem"
 			foreach ($link in $linkList) {
-				Write-Verbose "Processing the symlink: '$($link.Name)'."
+				Write-Verbose "Creating the symbolic-link item for: '$($link.Name)'."
 				
 				# Record the state for displaying at the end.
 				if ($link.Exists() -eq $false) {
 					$newList.Add($link)
 				}
-				elseif ($link.NeedsModification()) {
+				elseif ($link.State() -eq "NeedsDeletion" -or $link.State() -eq "NeedsCreation") {
 					$modifiedList.Add($link)
 				}
 				

--- a/Symlink/functions/Build-Symlink.ps1
+++ b/Symlink/functions/Build-Symlink.ps1
@@ -58,41 +58,44 @@ function Build-Symlink {
 	
 	begin {
 		# Store lists to notify user which symlinks were created/modified/etc.
-		$newList = New-Object System.Collections.Generic.List[psobject] 
-		$modifiedList = New-Object System.Collections.Generic.List[psobject]
+		$newList = New-Object System.Collections.Generic.List[Symlink] 
+		$modifiedList = New-Object System.Collections.Generic.List[Symlink]
 	}
 	
 	process {
 		if ($All) {
-			Write-Verbose "Creating all symlink items on the filesystem."
-			
 			# Read in all of the existing symlinks.
 			$linkList = Read-Symlinks
 			
+			Write-Verbose "Creating all symbolic-link items on the filesystem."
 			foreach ($link in $linkList) {
-				Write-Verbose "Processing the symlink: '$($link.Name)'."
+				Write-Verbose "Creating the symlink: '$($link.Name)'."
 				
+				# Record the state for displaying at the end.
 				if ($link.Exists() -eq $false) {
 					$newList.Add($link)
-				}elseif ($link.NeedsModification()) {
+				}
+				elseif ($link.NeedsModification()) {
 					$modifiedList.Add($link)
 				}
 				
 				# Create the symlink item on the filesystem.
 				$link.CreateFile()
 			}
-		}else {
-			Write-Verbose "Creating specified symlink items: '$Names' on the filesystem"
-			
+		}
+		else {
 			# Read in the specified symlinks.
 			$linkList = Get-Symlink -Names $Names -Verbose:$false
 			
+			Write-Verbose "Creating specified symbolic-link items: '$Names' on the filesystem"
 			foreach ($link in $linkList) {
 				Write-Verbose "Processing the symlink: '$($link.Name)'."
 				
+				# Record the state for displaying at the end.
 				if ($link.Exists() -eq $false) {
 					$newList.Add($link)
-				}elseif ($link.NeedsModification()) {
+				}
+				elseif ($link.NeedsModification()) {
 					$modifiedList.Add($link)
 				}
 				
@@ -113,5 +116,4 @@ function Build-Symlink {
 			Write-Output $modifiedList
 		}
 	}
-
 }

--- a/Symlink/functions/Build-Symlink.ps1
+++ b/Symlink/functions/Build-Symlink.ps1
@@ -14,6 +14,13 @@
 .PARAMETER All
 	Specifies to create all symlinks.
 	
+.PARAMETER WhatIf
+	Prints what actions would have been done in a proper run, but doesn't
+	perform any of them.
+	
+.PARAMETER Confirm
+	Prompts for user input for every "altering"/changing action.
+	
 .INPUTS
 	Symlink[]
 	System.String[]
@@ -41,7 +48,7 @@
 #>
 function Build-Symlink {
 	
-	[CmdletBinding(DefaultParameterSetName = "All")]
+	[CmdletBinding(DefaultParameterSetName = "All", SupportsShouldProcess = $true)]
 	param (
 		
 		# Tab completion.
@@ -79,7 +86,9 @@ function Build-Symlink {
 				}
 				
 				# Create the symlink item on the filesystem.
-				$link.CreateFile()
+				if ($PSCmdlet.ShouldProcess($link.FullPath(), "Create Symbolic-Link")) {
+					$link.CreateFile()
+				}
 			}
 		}
 		else {
@@ -98,7 +107,9 @@ function Build-Symlink {
 				}
 				
 				# Create the symlink item on the filesystem.
-				$link.CreateFile()
+				if ($PSCmdlet.ShouldProcess($link.FullPath(), "Create Symbolic-Link")) {
+					$link.CreateFile()
+				}
 			}
 		}
 	}

--- a/Symlink/functions/Get-Symlink.ps1
+++ b/Symlink/functions/Get-Symlink.ps1
@@ -23,7 +23,7 @@
 	-Names supports tab-completion.
 	
 .EXAMPLE
-	PS C:\> Get-Symlink -Names "data"
+	PS C:\> Get-Symlink -Name "data"
 	
 	This command will retrieve the details of the symlink named "data", and
 	output the information to the screen.
@@ -60,19 +60,18 @@ function Get-Symlink {
 	)
 	
 	begin {
-		# Store the retrieved symlinks, to output together at the end.
+		# Store the retrieved symlinks, to output together in one go at the end.
 		$outputList = New-Object System.Collections.Generic.List[Symlink]
 	}
 	
 	process {
 		if (-not $All) {
-			Write-Verbose "Retrieving specified symlinks: $Names."
 			# Read in the existing symlinks.
 			$linkList = Read-Symlinks
 			
 			# Iterate through all the passed in names.
 			foreach ($name in $Names) {
-				Write-Verbose "Processing the symlink: '$name'."
+				Write-Verbose "Retrieving the symlink: '$name'."
 				# If the link doesn't exist, warn the user.
 				$existingLink = $linkList | Where-Object { $_.Name -eq $name }
 				if ($null -eq $existingLink) {
@@ -83,9 +82,10 @@ function Get-Symlink {
 				# Add the symlink object.
 				$outputList.Add($existingLink)
 			}
-		}else {
+		}
+		else {
 			Write-Verbose "Retrieving all symlinks."
-			# Read in the existing symlinks, and pipe them all out.
+			# Read in all of the symlinks.
 			$outputList = Read-Symlinks
 		}
 	}
@@ -94,5 +94,4 @@ function Get-Symlink {
 		# By default, outputs in List formatting.
 		$outputList | Sort-Object -Property Name
 	}
-	
 }

--- a/Symlink/functions/New-Symlink.ps1
+++ b/Symlink/functions/New-Symlink.ps1
@@ -27,16 +27,17 @@
 	Skips the creation of the symbolic-link item on the filesystem.
 	
 .PARAMETER WhatIf
-	wip
+	Prints what actions would have been done in a proper run, but doesn't
+	perform any of them.
 	
 .PARAMETER Confirm
-	wip
+	Prompts for user input for every "altering"/changing action.
 	
 .INPUTS
 	None
 	
 .OUTPUTS
-	None
+	Symlink
 	
 .NOTES
 	For detailed help regarding the 'Creation Condition' scriptblock, see
@@ -120,11 +121,14 @@ function New-Symlink {
 	}
 	# Add the new link to the list, and then re-export the list.
 	$linkList.Add($newLink)
-	Write-Verbose "Re-exporting the modified database."
-	Export-Clixml -Path $script:DataPath -InputObject $linkList | Out-Null
+	if ($PSCmdlet.ShouldProcess("$script:DataPath", "Overwrite database with modified one")) {
+		Export-Clixml -Path $script:DataPath -InputObject $linkList -WhatIf:$false -Confirm:$false | Out-Null
+	}
 	
 	# Build the symlink item on the filesytem.
-	if (-not $DontCreateItem) {
+	if (-not $DontCreateItem -and $PSCmdlet.ShouldProcess($newLink.FullPath(), "Create Symbolic-Link")) {
 		$newLink.CreateFile()
 	}
+	
+	Write-Output $newLink
 }

--- a/Symlink/functions/New-Symlink.ps1
+++ b/Symlink/functions/New-Symlink.ps1
@@ -125,9 +125,6 @@ function New-Symlink {
 	
 	# Build the symlink item on the filesytem.
 	if (-not $DontCreateItem) {
-		Write-Verbose "Creating the symbolic-link item on the filesytem."
 		$newLink.CreateFile()
 	}
-	
-	# TODO: Output symlink object.
 }

--- a/Symlink/functions/Remove-Symlink.ps1
+++ b/Symlink/functions/Remove-Symlink.ps1
@@ -16,10 +16,11 @@
 	link will remain afterwads.
 	
 .PARAMETER WhatIf
-	wip
+	Prints what actions would have been done in a proper run, but doesn't
+	perform any of them.
 	
 .PARAMETER Confirm
-	wip
+	Prompts for user input for every "altering"/changing action.
 	
 .INPUTS
 	Symlink[]
@@ -77,12 +78,12 @@ function Remove-Symlink {
 			# If the link doesn't exist, warn the user.
 			$existingLink = $linkList | Where-Object { $_.Name -eq $name }
 			if ($null -eq $existingLink) {
-				Write-Error "There is no symlink called: '$name'."
+				Write-Warning "There is no symlink called: '$name'."
 				continue
 			}
 			
 			# Delete the symlink from the filesystem.
-			if (-not $DontDeleteItem) {
+			if (-not $DontDeleteItem -and $PSCmdlet.ShouldProcess($existingLink.FullPath(), "Delete Symbolic-Link")) {
 				$existingLink.DeleteFile()
 			}
 			
@@ -91,7 +92,8 @@ function Remove-Symlink {
 		}
 		
 		# Re-export the list.
-		Write-Verbose "Re-exporting the modified database."
-		Export-Clixml -Path $script:DataPath -InputObject $linkList | Out-Null
+		if ($PSCmdlet.ShouldProcess("$script:DataPath", "Overwrite database with modified one")) {
+			Export-Clixml -Path $script:DataPath -InputObject $linkList -WhatIf:$false -Confirm:$false | Out-Null
+		}
 	}
 }

--- a/Symlink/functions/Remove-Symlink.ps1
+++ b/Symlink/functions/Remove-Symlink.ps1
@@ -83,7 +83,6 @@ function Remove-Symlink {
 			
 			# Delete the symlink from the filesystem.
 			if (-not $DontDeleteItem) {
-				Write-Verbose "Deleting the symbolic-link item from the filesystem."
 				$existingLink.DeleteFile()
 			}
 			

--- a/Symlink/functions/Remove-Symlink.ps1
+++ b/Symlink/functions/Remove-Symlink.ps1
@@ -32,7 +32,7 @@
 	-Names supports tab-completion.
 	
 .EXAMPLE
-	PS C:\> Remove-Symlink -Names "data"
+	PS C:\> Remove-Symlink -Name "data"
 	
 	This command will remove a symlink definition, named "data", and delete the
 	symbolic-link item from the filesystem.
@@ -43,6 +43,12 @@
 	This command will remove the symlink definitions named "data" and "files",
 	and delete the symbolic-link items of both.
   ! You can pipe the names to this command instead.
+	
+.EXAMPLE
+	PS C:\> Remove-Symlink -Name "data" -DontDeleteItem
+	
+	This command will remove a symlink definition, named "data", but it will
+	keep the symbolic-link item on the filesystem.
 	
 #>
 function Remove-Symlink {
@@ -62,23 +68,22 @@ function Remove-Symlink {
 		
 	)
 	
-	# Process block since this function accepts pipeline input.
 	process {
+		# Read in the existing symlinks.
+		$linkList = Read-Symlinks
+		
 		foreach ($name in $Names) {
-			Write-Verbose "Processing the symlink: '$name'."
-			# Read in the existing symlinks.
-			$linkList = Read-Symlinks
-				
+			Write-Verbose "Removing the symlink: '$name'."
 			# If the link doesn't exist, warn the user.
 			$existingLink = $linkList | Where-Object { $_.Name -eq $name }
 			if ($null -eq $existingLink) {
 				Write-Error "There is no symlink called: '$name'."
-				return
+				continue
 			}
 			
 			# Delete the symlink from the filesystem.
 			if (-not $DontDeleteItem) {
-				Write-Verbose "Deleting the symlink item from the filesystem."
+				Write-Verbose "Deleting the symbolic-link item from the filesystem."
 				$existingLink.DeleteFile()
 			}
 			
@@ -89,7 +94,5 @@ function Remove-Symlink {
 		# Re-export the list.
 		Write-Verbose "Re-exporting the modified database."
 		Export-Clixml -Path $script:DataPath -InputObject $linkList | Out-Null
-			
 	}
-	
 }

--- a/Symlink/functions/Set-Symlink.ps1
+++ b/Symlink/functions/Set-Symlink.ps1
@@ -102,7 +102,7 @@ function Set-Symlink {
 			$existingLink.Name = $Value
 		}
 		elseif ($Property -eq "Path") {
-			Write-Verbose "Changing the path to: '$Path'."
+			Write-Verbose "Changing the path to: '$Value'."
 			# First delete the symlink at the original path.
 			$existingLink.DeleteFile()
 			
@@ -115,7 +115,8 @@ function Set-Symlink {
 			Write-Verbose "Changing the target to: '$Value'."
 			
 			# Validate that the target exists.
-			if (-not (Test-Path -Path ([System.Environment]::ExpandEnvironmentVariables($Value)))) {
+			if (-not (Test-Path -Path ([System.Environment]::ExpandEnvironmentVariables($Value)) `
+					-ErrorAction Ignore)) {
 				Write-Error "The target path: '$Value' points to an invalid location!"
 				return
 			}

--- a/Symlink/functions/Set-Symlink.ps1
+++ b/Symlink/functions/Set-Symlink.ps1
@@ -18,10 +18,11 @@
 	The new value for the property to take.
 	
 .PARAMETER WhatIf
-	wip
+	Prints what actions would have been done in a proper run, but doesn't
+	perform any of them.
 	
 .PARAMETER Confirm
-	wip
+	Prompts for user input for every "altering"/changing action.
 	
 .INPUTS
 	Symlink[]
@@ -104,12 +105,16 @@ function Set-Symlink {
 		elseif ($Property -eq "Path") {
 			Write-Verbose "Changing the path to: '$Value'."
 			# First delete the symlink at the original path.
-			$existingLink.DeleteFile()
+			if ($PSCmdlet.ShouldProcess($existingLink.FullPath(), "Delete Symbolic-Link")) {
+				$existingLink.DeleteFile()
+			}
 			
 			# Then change the path property, and re-create the symlink
 			# at the new location.
 			$existingLink._Path = $Value
-			$existingLink.CreateFile()
+			if ($PSCmdlet.ShouldProcess($existingLink.FullPath(), "Create Symbolic-Link")) {
+				$existingLink.CreateFile()
+			}
 		}
 		elseif ($Property -eq "Target") {
 			Write-Verbose "Changing the target to: '$Value'."
@@ -123,7 +128,9 @@ function Set-Symlink {
 			
 			# Change the target property, and edit the existing symlink (re-create).
 			$existingLink._Target = $Value
-			$existingLink.CreateFile()
+			if ($PSCmdlet.ShouldProcess($existingLink.FullPath(), "Update Symbolic-Link target")) {
+				$existingLink.CreateFile()
+			}
 		}
 		elseif ($Property -eq "CreationCondition") {
 			Write-Verbose "Changing the creation condition."
@@ -133,7 +140,8 @@ function Set-Symlink {
 		}
 		
 		# Re-export the list.
-		Write-Verbose "Re-exporting the modified database."
-		Export-Clixml -Path $script:DataPath -InputObject $linkList | Out-Null
+		if ($PSCmdlet.ShouldProcess("$script:DataPath", "Overwrite database with modified one")) {
+			Export-Clixml -Path $script:DataPath -InputObject $linkList -WhatIf:$false -Confirm:$false | Out-Null
+		}
 	}
 }

--- a/Symlink/internal/classes/Symlink.ps1
+++ b/Symlink/internal/classes/Symlink.ps1
@@ -118,25 +118,24 @@ class Symlink {
 				
 				if ($null -eq (Get-Item -Path $this.FullPath() -ErrorAction Ignore)) {
 					# There is no existing item or symlink, so just create the new symlink.
-					Write-Verbose "Creating new symbolic-link item on the filesystem."
 				}
 				elseif ([System.String]::IsNullOrWhiteSpace($target)) {
 					# There is an existing item, so remove it.
-					Write-Verbose "Creating new symbolic-link item on the filesystem. Deleting existing folder/file first."
+					Write-Verbose "Deleting existing folder/file first."
 					try {
-						Remove-Item -Path $this.FullPath() -Force -Recurse
+						Remove-Item -Path $this.FullPath() -Force -Recurse -WhatIf:$false -Confirm:$false
 					}
 					catch {
 						Write-Warning "The existing item could not be deleted. It may be in use by another program."
 						Write-Warning "Please close any programs which are accessing files via this folder/file."
 						Read-Host -Prompt "Press any key to continue..."
-						Remove-Item -Path $this.FullPath() -Force -Recurse
+						Remove-Item -Path $this.FullPath() -Force -Recurse -WhatIf:$false -Confirm:$false
 					}
 				}
 				elseif ($target -ne $this.FullTarget()) {
 					# There is an existing symlink, so remove it.
 					# Must be done by calling the 'Delete()' method, rather than 'Remove-Item'.
-					Write-Verbose "Changing the symbolic-link item target (deleting and re-creating)."
+					Write-Verbose "Changing the existing symbolic-link item target (deleting and re-creating)."
 					try {
 						(Get-Item -Path $this.FullPath()).Delete()
 					}
@@ -149,7 +148,8 @@ class Symlink {
 				}
 				
 				# Create the new symlink.
-				New-Item -ItemType SymbolicLink -Force -Path $this.FullPath() -Value $this.FullTarget() | Out-Null
+				New-Item -ItemType SymbolicLink -Force -Path $this.FullPath() -Value $this.FullTarget() `
+					-WhatIf:$false -Confirm:$false | Out-Null
 			}
 		}
 	}
@@ -157,7 +157,6 @@ class Symlink {
 	[void] DeleteFile() {
 		# Check that the actual symlink item exists first.
 		if ($this.Exists()) {
-			Write-Verbose "Deleting the symbolic-link item from the filesystem."
 			# Loop until the symlink item can be successfuly deleted.
 			$state = $true
 			while ($state -eq $true) {


### PR DESCRIPTION
Release v0.1.1
 - Update: about_pages: Add information regarding common parameters.
 - Update: help_descriptions: Extra examples for all commands.
 - Update: output: Improve verbose logging to make it clearer and more succinct.
 - Fix: Build-Symlink: Error when calling now-removed method on the \[Symlink\] object.
 - Add: should_process: Support for most commands to use the -WhatIf and -Confirm switches.
 - Update: New-Symlink: Outputs the newly-created \[Symlink\] object at the end.
 - Fix: error_status: Only sets the $error variable if a true error has occured.